### PR TITLE
[DOI-1028] Adjust user creation endpoint to new model

### DIFF
--- a/DopplerBeplic.Tests/AuthorizationTest.cs
+++ b/DopplerBeplic.Tests/AuthorizationTest.cs
@@ -99,6 +99,6 @@ public class AuthorizationTest
         Assert.Equal(HttpStatusCode.Created, response.StatusCode);
         // TODo: do better verifications in another test different than AuthorizationTest
         beplicServiceMock.Verify(x => x.CreateUser(It.Is<UserCreationDTO>(accountData =>
-            accountData.Customer != null && accountData.Plan == null && accountData.Room == null)));
+            accountData.Customer != null && accountData.Customer.Plan == null && accountData.Room == null)));
     }
 }

--- a/doppler-beplic/Models/Config/DefaultValuesoptions.cs
+++ b/doppler-beplic/Models/Config/DefaultValuesoptions.cs
@@ -14,6 +14,7 @@ namespace DopplerBeplic.Models.Config
 
         public string Name { get; set; } = string.Empty;
         public string Group { get; set; } = string.Empty;
+        public string Channel { get; set; } = string.Empty;
     }
 
     public class DefaultPlan

--- a/doppler-beplic/Models/DTO/CompanyUpdateDTO.cs
+++ b/doppler-beplic/Models/DTO/CompanyUpdateDTO.cs
@@ -1,11 +1,11 @@
 namespace DopplerBeplic.Models.DTO
 {
-    public class CustomerUpdateDTO
+    public class CompanyUpdateDTO
     {
-        public required CustomerUpdateData Customer { get; set; }
+        public required CompanyUpdateData Customer { get; set; }
     }
 
-    public class CustomerUpdateData
+    public class CompanyUpdateData
     {
         public string Cuit { get; set; } = string.Empty;
         public string Address { get; set; } = string.Empty;

--- a/doppler-beplic/Models/DTO/UserCreationDTO.cs
+++ b/doppler-beplic/Models/DTO/UserCreationDTO.cs
@@ -1,46 +1,76 @@
+using Newtonsoft.Json;
+
 namespace DopplerBeplic.Models.DTO
 {
     public class UserCreationDTO
     {
+        [JsonProperty("customer")]
         public required UserCreationCustomer Customer { get; set; }
+        [JsonProperty("room")]
         public UserCreationRoom? Room { get; set; }
-        public UserCreationPlan? Plan { get; set; }
     }
 
     public class UserCreationCustomer
     {
+        [JsonProperty("cuit")]
         public string Cuit { get; set; } = string.Empty;
+        [JsonProperty("address")]
         public string Address { get; set; } = string.Empty;
+        [JsonProperty("razonSocial")]
         public string BusinessName { get; set; } = string.Empty;
+        [JsonProperty("legalName")]
         public string LegalName { get; set; } = string.Empty;
+        [JsonProperty("idExternal")]
         public string IdExternal { get; set; } = string.Empty;
+        [JsonProperty("apiKey")]
         public string ApiKey { get; set; } = string.Empty;
+        [JsonProperty("plan")]
+        public UserCreationPlan? Plan { get; set; }
+        [JsonProperty("userAdmin")]
         public CustomerUserAdmin UserAdmin { get; set; } = new CustomerUserAdmin();
     }
 
     public class CustomerUserAdmin
     {
+        [JsonProperty("email")]
         public string Email { get; set; } = string.Empty;
+        [JsonProperty("firstName")]
         public string FirstName { get; set; } = string.Empty;
+        [JsonProperty("lastName")]
         public string LastName { get; set; } = string.Empty;
+        [JsonProperty("celphone")]
         public string Cellphone { get; set; } = string.Empty;
     }
 
     public class UserCreationRoom
     {
+        [JsonProperty("name")]
         public string? RoomName { get; set; }
+        [JsonProperty("group")]
         public RoomGroup? Group { get; set; }
+        [JsonProperty("channel")]
+        public RoomChannel? Channel { get; set; }
     }
 
     public class RoomGroup
     {
+        [JsonProperty("name")]
         public string? GroupName { get; set; }
+    }
+
+    public class RoomChannel
+    {
+        [JsonProperty("name")]
+        public string? ChannelName { get; set; }
     }
 
     public class UserCreationPlan
     {
+        [JsonProperty("idPlan")]
         public int? IdPlan { get; set; }
+        [JsonProperty("name")]
         public string? PlanName { get; set; }
+        [JsonProperty("messageLimit")]
         public int? MessageLimit { get; set; }
     }
 }

--- a/doppler-beplic/Models/Responses/CompanyUpdateResponse.cs
+++ b/doppler-beplic/Models/Responses/CompanyUpdateResponse.cs
@@ -1,6 +1,6 @@
 namespace DopplerBeplic.Models.Responses
 {
-    public class CustomerUpdateResponse
+    public class CompanyUpdateResponse
     {
         public bool Success { get; set; }
         public string? Message { get; set; }

--- a/doppler-beplic/Models/Responses/UserCreationResponse.cs
+++ b/doppler-beplic/Models/Responses/UserCreationResponse.cs
@@ -6,5 +6,6 @@ namespace DopplerBeplic.Models.Responses
         public int? CustomerId { get; set; }
         public string? Error { get; set; }
         public string? ErrorStatus { get; set; }
+        public string? UserToken { get; set; }
     }
 }

--- a/doppler-beplic/Program.cs
+++ b/doppler-beplic/Program.cs
@@ -120,11 +120,11 @@ app.MapPut("/user", async Task<Results<Ok<string>, BadRequest<string>>> (
 .WithOpenApi()
 .RequireAuthorization(Policies.OnlySuperuser);
 
-app.MapPut("/customer", async Task<Results<Ok<string>, BadRequest<string>>> (
+app.MapPut("/company", async Task<Results<Ok<string>, BadRequest<string>>> (
     IBeplicService beplicService,
-    [FromBody] CustomerUpdateDTO body) =>
+    [FromBody] CompanyUpdateDTO body) =>
 {
-    var response = await beplicService.UpdateCustomer(body);
+    var response = await beplicService.UpdateCompany(body);
 
     return response.Success ?
         TypedResults.Ok(string.Format(CultureInfo.InvariantCulture, "Company updated for CustomerId: {0}", response.CustomerId))

--- a/doppler-beplic/Program.cs
+++ b/doppler-beplic/Program.cs
@@ -2,11 +2,13 @@ using System.Globalization;
 using DopplerBeplic.DopplerSecurity;
 using DopplerBeplic.Models.Config;
 using DopplerBeplic.Models.DTO;
+using DopplerBeplic.Models.Responses;
 using DopplerBeplic.Services.Classes;
 using DopplerBeplic.Services.Interfaces;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -37,6 +39,12 @@ builder.Services.Configure<ApiConnectionOptions>(
     builder.Configuration.GetSection(ApiConnectionOptions.Connection));
 builder.Services.Configure<DefaulValuesOptions>(
     builder.Configuration.GetSection(DefaulValuesOptions.Values));
+
+builder.Services.ConfigureHttpJsonOptions(o => {
+    o.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
+    o.SerializerOptions.WriteIndented = true;
+    o.SerializerOptions.IncludeFields = true;
+});
 
 // Add services to the container.
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
@@ -78,14 +86,14 @@ if (app.Environment.IsDevelopment())
 
 app.UseHttpsRedirection();
 
-app.MapPost("/account", async Task<Results<Created<string>, BadRequest<string>>> (
+app.MapPost("/account", async Task<Results<Created<UserCreationResponse>, BadRequest<string>>> (
     IBeplicService beplicService,
     [FromBody] UserCreationDTO body) =>
 {
     var response = await beplicService.CreateUser(body);
 
     return response.Success ?
-        TypedResults.Created("/", string.Format(CultureInfo.InvariantCulture, "User created with ID:{0}", response.CustomerId))
+        TypedResults.Created("/", response)
         : TypedResults.BadRequest(
             string.Format(
                 CultureInfo.InvariantCulture,

--- a/doppler-beplic/Program.cs
+++ b/doppler-beplic/Program.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text.Json.Serialization;
 using DopplerBeplic.DopplerSecurity;
 using DopplerBeplic.Models.Config;
 using DopplerBeplic.Models.DTO;
@@ -8,7 +9,6 @@ using DopplerBeplic.Services.Interfaces;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.OpenApi.Models;
-using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -40,7 +40,8 @@ builder.Services.Configure<ApiConnectionOptions>(
 builder.Services.Configure<DefaulValuesOptions>(
     builder.Configuration.GetSection(DefaulValuesOptions.Values));
 
-builder.Services.ConfigureHttpJsonOptions(o => {
+builder.Services.ConfigureHttpJsonOptions(o =>
+{
     o.SerializerOptions.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
     o.SerializerOptions.WriteIndented = true;
     o.SerializerOptions.IncludeFields = true;

--- a/doppler-beplic/Services/Classes/BeplicSdk.cs
+++ b/doppler-beplic/Services/Classes/BeplicSdk.cs
@@ -4,6 +4,7 @@ using DopplerBeplic.Models.Config;
 using Microsoft.Extensions.Options;
 using Newtonsoft.Json;
 using RestSharp;
+using RestSharp.Serializers.NewtonsoftJson;
 
 namespace DopplerBeplic.Services.Classes
 {
@@ -35,7 +36,9 @@ namespace DopplerBeplic.Services.Classes
         {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls13;
 
-            return new RestClient(_options.BaseUrl);
+            return new RestClient(
+                _options.BaseUrl,
+                configureSerialization: s => s.UseNewtonsoftJson());
         }
 
         private async Task Authenticate()

--- a/doppler-beplic/Services/Classes/BeplicService.cs
+++ b/doppler-beplic/Services/Classes/BeplicService.cs
@@ -93,9 +93,9 @@ namespace DopplerBeplic.Services.Classes
             return result;
         }
 
-        public async Task<CustomerUpdateResponse> UpdateCustomer(CustomerUpdateDTO customerData)
+        public async Task<CompanyUpdateResponse> UpdateCompany(CompanyUpdateDTO customerData)
         {
-            var result = new CustomerUpdateResponse();
+            var result = new CompanyUpdateResponse();
 
             try
             {

--- a/doppler-beplic/Services/Classes/BeplicService.cs
+++ b/doppler-beplic/Services/Classes/BeplicService.cs
@@ -25,10 +25,14 @@ namespace DopplerBeplic.Services.Classes
                 Group = new RoomGroup
                 {
                     GroupName = _options.Room.Group
+                },
+                Channel = new RoomChannel
+                {
+                    ChannelName = _options.Room.Channel
                 }
             };
 
-            accountData.Plan ??= new UserCreationPlan
+            accountData.Customer.Plan ??= new UserCreationPlan
             {
                 IdPlan = _options.Plan.Id,
                 PlanName = _options.Plan.Name,
@@ -39,7 +43,7 @@ namespace DopplerBeplic.Services.Classes
 
             try
             {
-                var response = await _sdk.ExecuteResource("v1/integra/customer", accountData, RestSharp.Method.Post);
+                var response = await _sdk.ExecuteResource("/services/beplicconfigurationintegra/v1/integra/customers", accountData, RestSharp.Method.Post);
 
                 if (response.IsSuccessStatusCode)
                 {
@@ -49,13 +53,15 @@ namespace DopplerBeplic.Services.Classes
                         message = string.Empty,
                         data = new
                         {
-                            idCustomer = 0
+                            idCustomer = 0,
+                            accessToken = string.Empty
                         }
                     });
 
                     result.Success = deserealizedResponse?.success ?? false;
-                    result.Error = result.Success ? string.Empty : deserealizedResponse?.message;
+                    result.Error = result.Success ? null : deserealizedResponse?.message;
                     result.CustomerId = deserealizedResponse?.data.idCustomer;
+                    result.UserToken = deserealizedResponse?.data.accessToken;
                 }
                 else
                 {

--- a/doppler-beplic/Services/Interfaces/IBeplicService.cs
+++ b/doppler-beplic/Services/Interfaces/IBeplicService.cs
@@ -7,7 +7,7 @@ namespace DopplerBeplic.Services.Interfaces
     {
         Task<UserCreationResponse> CreateUser(UserCreationDTO accountData);
 
-        Task<CustomerUpdateResponse> UpdateCustomer(CustomerUpdateDTO customerData);
+        Task<CompanyUpdateResponse> UpdateCompany(CompanyUpdateDTO customerData);
 
         Task<UserAdminUpdateResponse> UpdateUserAdmin(UserAdminUpdateDTO userAdminData);
     }

--- a/doppler-beplic/appsettings.json
+++ b/doppler-beplic/appsettings.json
@@ -14,7 +14,8 @@
   "DefaultValues": {
     "Room": {
       "Name": "Sala A",
-      "Group": "Grupo A"
+      "Group": "Grupo A",
+      "Channel": "WhatsApp"
     },
     "Plan": {
       "Id": 5,

--- a/doppler-beplic/doppler-beplic.csproj
+++ b/doppler-beplic/doppler-beplic.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.18.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="RestSharp" Version="110.2.0" />
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="110.2.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Recently beplic made some changes to the model they provided before, so we need to adjust to that.
In this PR I enclosed a few changes:

- Serialization through newtonSoft with JsonProperties.
- Return UserToken on user creation response.
- Configure default serialization behavior.
- Replace customer for company (Forgot to push the changes on previous PR 🤦‍♂️)