### PR TITLE
chore: update fromdoppler.yml

### DIFF
--- a/.github/workflows/fromdoppler.yml
+++ b/.github/workflows/fromdoppler.yml
@@ -18,5 +18,5 @@ jobs:
     uses: FromDoppler/.github/.github/workflows/continuous-delivery-dockerfile.yml@main
     secrets: inherit
     with:
-      dockerfile-path: "Dockerfile"
-      dockerhub-image-name: "doppler-dockerhub-image-name-example"
+      dockerfile-path: "doppler-beplic/Dockerfile"
+      dockerhub-image-name: "doppler-beplic"


### PR DESCRIPTION
This is for properly generating docker images with GitHub actions provided by FromDoppler Org